### PR TITLE
Lowpassfilter

### DIFF
--- a/src/NovaAhrs.cpp
+++ b/src/NovaAhrs.cpp
@@ -13,8 +13,9 @@
 #include <sys/ioctl.h>
 #include <linux/i2c-dev.h>
 #include <stdio.h>
+#include <cmath.h>
 #include <sys/time.h>
-
+#include "utils/lowpassfilter.h"
 #include <nova_common/IMU.h>
 FusionBias fusionBias;
 FusionAhrs fusionAhrs;
@@ -112,10 +113,10 @@ int main(int argc, char **argv) {
 	// Initialise low pass filter for the magnetometer
 
 	int timeConstant = 1000; //1 second time constant for now
-	int millisecondSamplePeriod= 1000*samplePeriod
-	lowpassfilter smoothed_mag_x(timeConstant, millisecondSamplePeriod); 
-	lowpassfilter smoothed_mag_y(timeConstant, millisecondSamplePeriod);
-	lowpassfilter smoothed_mag_z(timeConstant, millisecondSamplePeriod);
+	int milliSamplePeriod =floor(1000*samplePeriod)
+	lowpassfilter smoothed_mag_x(timeConstant, milliSamplePeriod); 
+	lowpassfilter smoothed_mag_y(timeConstant, milliSamplePeriod);
+	lowpassfilter smoothed_mag_z(timeConstant, milliSamplePeriod);
 
 	//main loop
 	do {	

--- a/src/NovaAhrs.cpp
+++ b/src/NovaAhrs.cpp
@@ -112,10 +112,10 @@ int main(int argc, char **argv) {
 	// Initialise low pass filter for the magnetometer
 
 	int timeConstant = 1000; //1 second time constant for now
-	int milisSamplePeriod= 1000*samplePeriod
-	lowpassfilter smoothed_mag_x(timeConstant, milisSamplePeriod); 
-	lowpassfilter smoothed_mag_y(timeConstant, milisSamplePeriod);
-	lowpassfilter smoothed_mag_z(timeConstant, milisSamplePeriod);
+	int millisecondSamplePeriod= 1000*samplePeriod
+	lowpassfilter smoothed_mag_x(timeConstant, millisecondSamplePeriod); 
+	lowpassfilter smoothed_mag_y(timeConstant, millisecondSamplePeriod);
+	lowpassfilter smoothed_mag_z(timeConstant, millisecondSamplePeriod);
 
 	//main loop
 	do {	

--- a/src/utils/lowpassfilter.cpp
+++ b/src/utils/lowpassfilter.cpp
@@ -1,0 +1,12 @@
+#include "lowpassfilter.h" 
+#include <math.h>
+FirstOrderLowPass::FirstOrderLowPass(int time_constant_millis,
+                                           int sample_period_millis)
+    : state(0),
+      alpha(exp(-(static_cast<double>(sample_period_millis)) /
+                (static_cast<double>(time_constant_millis)))) {}
+
+double FirstOrderLowPass::ProcessSample(float new_sample) {
+    state = alpha * state + (1 - alpha) * new_sample;
+    return state;
+}

--- a/src/utils/lowpassfilter.h
+++ b/src/utils/lowpassfilter.h
@@ -1,0 +1,11 @@
+// A basic low pass filter to be used to refine magnetometer estimates
+
+
+class FirstOrderLowPass{
+    public: 
+    FirstOrderLowPass(int timeConstantMil, int samplePeriodMil); 
+    double ProcessSample(float sample);
+    private:
+    float state; 
+    float alpha;  
+}


### PR DESCRIPTION
1. Implements a low pass filter class that can be accessed by #include "utils/lowpassfilter.h" 
2. Uses that low pass filter to smooth the magnetometer data (can be extended to include the gyro and other sensors) 
3. Publishes a new ros message for the filtered magnetic field. 
4. Changes the name of the unfiltered magnetometer topic to something that makes it clear it is unfiltered. (It doesnt look like this breaks anything as far as I can tell) 

